### PR TITLE
Add Testing Examples subsection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,10 @@ ivoatex/Makefile:
 	@echo "*** ivoatex submodule not found.  Initialising submodules."
 	@echo
 	git submodule update --init
+
+STILTS ?= stilts
+
+# This test needs STILTS (http://www.starlink.ac.uk/stilts/)
+test:
+	$(STILTS) votlint votable=fields-container.xml
+

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ DOCTYPE = NOTE
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex
-SOURCES = $(DOCNAME).tex svnsubstitution.tex verbatimstyles.tex gitmeta.tex
+SOURCES = $(DOCNAME).tex svnsubstitution.tex verbatimstyles.tex gitmeta.tex \
+          fields.xml fields-container.xml
 
 # List of pixel image files to be included in submitted package 
 FIGURES = triangle_workflow.png

--- a/fields-container.xml
+++ b/fields-container.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0'?>
+<!DOCTYPE VOTABLE [ <!ENTITY fields SYSTEM 'fields.xml'> ]>
+<VOTABLE version='1.4' xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
+  <RESOURCE>
+    <TABLE>
+      &fields;
+    </TABLE>
+  </RESOURCE>
+</VOTABLE>

--- a/fields.xml
+++ b/fields.xml
@@ -1,0 +1,3 @@
+  <!-- Define columns like this for sky position -->
+  <FIELD name="RA" datatype="double" ucd="pos.eq.ra;meta.main"/>
+  <FIELD name="Dec" datatype="double" ucd="pos.eq.dec;meta.main"/>

--- a/ivoatexDoc.tex
+++ b/ivoatexDoc.tex
@@ -606,6 +606,7 @@ Thus, all \ivoatex\ documents must have an abstract within the
 \texword{abstract} environment.
 
 \subsection{Listings, Verbatim Material}
+\label{sect:verbatim}
 
 \ivoatex\ documents should use the \texword{listings} package to include
 source code snippets, XML fragments and the like.  While the ivoa class
@@ -1292,6 +1293,45 @@ documentation\footnote{\url{http://www.starlink.ac.uk/stilts/sun256/cmdUsage.htm
 for details.
 In particular it is a good idea to validate all example VOTable documents
 included in document text.
+
+\subsubsection{Testing Examples}
+
+It is important to ensure correctness of literal example text appearing
+in document content;
+mistakes in examples confuse readers,
+often get cut and pasted into operational systems,
+and usually make it necessary to issue a document Erratum at a later date.
+
+Mistakes in hand-written XML are particularly easy to make,
+so providing Makefile tests for XML examples is strongly recommended.
+This can be done by storing XML content in a file separate to the
+document \LaTeX\ file and importing it with the \verb|\lstinputlisting|
+macro as described in sect.~\ref{sect:verbatim}.
+The XML file can then be tested (checked for well-formedness and,
+where possible, validated) from a Makefile test target without reference
+to the \LaTeX\ source.
+
+If the included XML does not represent a complete document, it may be
+necessary to use a container document that includes it using an
+external entity reference defined in an internal DTD subset.
+For example, suppose you want to include the following example text:
+\lstinputlisting[basicstyle=\footnotesize]{fields.xml}
+You can store that text in a file named \verb|fields.xml| and
+include it in the \LaTeX\ source like:
+\begin{lstlisting}[basicstyle=\footnotesize]
+\lstinputlisting{fields.xml}
+\end{lstlisting}
+Then prepare a container document \verb|fields-container.xml| like:
+\lstinputlisting[basicstyle=\footnotesize]{fields-container.xml}
+and include a \verb|test| target in the Makefile like:
+\begin{lstlisting}[basicstyle=\footnotesize]
+# This test needs STILTS
+test:
+        $(STILTS) votlint votable=fields-container.xml
+\end{lstlisting}
+See the build of this section of this document for an
+example of this technique in use.
+
 
 \subsection{Submitting a Document}
 

--- a/ivoatexDoc.tex
+++ b/ivoatexDoc.tex
@@ -1329,8 +1329,6 @@ and include a \verb|test| target in the Makefile like:
 test:
         $(STILTS) votlint votable=fields-container.xml
 \end{lstlisting}
-See the build of this section of this document for an
-example of this technique in use.
 
 
 \subsection{Submitting a Document}


### PR DESCRIPTION
Includes an example of how to include XML subdocuments using an
external entity defined in an internal DTD subset.
The technique described is itself used by the build/test of this
document.