### PR TITLE
adding pdf2svg in linux dependencies building examples

### DIFF
--- a/ivoatexDoc.tex
+++ b/ivoatexDoc.tex
@@ -211,15 +211,16 @@ package managers.
 
 On Debian-derived systems, the dependencies should be present after
 running a distribution-specific adaption of
-\begin{lstlisting}[basicstyle=\footnotesize]
-apt install build-essential texlive-latex-extra zip xsltproc git latexmk\
-  texlive-bibtex-extra imagemagick ghostscript cm-super librsvg2-bin
+\begin{lstlisting}
+apt install build-essential texlive-latex-extra zip xsltproc git\
+  latexmk texlive-bibtex-extra imagemagick ghostscript cm-super\
+  librsvg2-bin pdf2svg
 \end{lstlisting}
 (cm-super contains vector versions of computer modern fonts in T1
 encoding), on RPM-based systems something like
 \begin{lstlisting}
 yum install texlive-scheme-full libxslt make gcc zip\
-  ImageMagick ghostscript git
+  ImageMagick ghostscript git pdf2svg
 \end{lstlisting}
 should pull in everything that is necessary.
 


### PR DESCRIPTION
`pdf2svg` is listed in the dependencies _if_ TikZ images are in the doc.
This pull request simply covers that dependency setup in the example command lines for linux.